### PR TITLE
Sandboxed iframe plus more

### DIFF
--- a/src/bunsen-app/bunsen-app.html
+++ b/src/bunsen-app/bunsen-app.html
@@ -54,7 +54,7 @@
         </tr>
       </tbody>
     </table>
-    <iframe id="view" style="width:100%"></iframe>
+    <iframe id="view" style="width:100%" sandbox="allow-scripts allow-forms allow-modals allow-pointer-lock allow-orientation-lock allow-presentation" allowfullscreen allowpaymentrequest></iframe>
     <bunsen-dats id="datSites"></bunsen-dats>
     <div id="peerage">
       <p style="margin: 5px">Peers</p>


### PR DESCRIPTION
Sandboxing the iframe will help keep webpages from messing with the UI (stuff like top.location.replace was able to redirect the user from the Bunsen UI entirely) and I set it to allow as much as possible to not break whatever developers would expect to happen.

I also threw in the allowfullscreen and allowpaymentrequest attributes just incase (I'm unsure if they'll work, but it's worth a shot).